### PR TITLE
Fixes issue not finding GPU devices on EC2 VMs

### DIFF
--- a/api/proto/worker.proto
+++ b/api/proto/worker.proto
@@ -139,6 +139,7 @@ message PCIInfo {
     Class.SubClass subclass = 5;
     Class.ProgrammingInterface pi = 6;
     string driver = 7;
+    string address = 8;
   }
   repeated Device devices = 1;
 
@@ -178,7 +179,6 @@ message GPUInfo {
     uint32 index = 1;
     string address = 2;
     PCIInfo.Device device = 3;
-    TopologyInfo.Node node = 4;
   }
   repeated Card card = 1;
 }


### PR DESCRIPTION
EC2 GPUs not stored in /sys/class/drm where ghw was checking. So
instead, we check through the PCI devices looking for Display
Controllers. This can be adjusted later to search for Display Controller
 subclasses to remove integrated graphics and such.

 Fixes #32

Signed-off-by: Anshul Gupta <ansg191@yahoo.com>